### PR TITLE
Fix for issue #27

### DIFF
--- a/students/forms.py
+++ b/students/forms.py
@@ -19,7 +19,7 @@ class StudentFeeAdd(forms.ModelForm):
             valid_until = valid,
             )
 
-        if len(qs) is not 0:
+        if len(qs) != 0:
             raise forms.ValidationError("Fee for this month has been submitted.")
         return self.cleaned_data
 


### PR DESCRIPTION
changed "is not" to "!="
changed to fix issue #27

```
C:\code\easy-school\students\forms.py:22: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(qs) is not 0:
Migrations for 'students':
  students\migrations\0025_auto_20200402_0743.py
    - Alter field valid_until on studentfee
```